### PR TITLE
Fix incorrect JSON parsing for pull requests

### DIFF
--- a/runner-entrypoint.sh
+++ b/runner-entrypoint.sh
@@ -8,7 +8,7 @@ if [ -f $GITHUB_EVENT_PATH ]; then
 	if [ -z "$BRANCH" ]
     then
     	# in case of pullresuest event
-    	BRANCH=$(cat $GITHUB_EVENT_PATH | jq -r head.ref)
+    	BRANCH=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.ref)
     fi
 else
 	echo "Required file on path 'GITHUB_EVENT_PATH' not exists"


### PR DESCRIPTION
Kept getting errors from `jq` while configuring it for a pull request - I think the issue was a missing `pull_request` prefix - tested locally on the payload, seems to work. Not sure how to "test run' it on the market place.

The error:
```log
jq: error: head/0 is not defined at <top-level>, line 1:
head.ref
jq: 1 compile error
```